### PR TITLE
Clean up globals

### DIFF
--- a/src/macros/consts.eg
+++ b/src/macros/consts.eg
@@ -50,6 +50,7 @@ global_variables = {
    .clone
    .console
    .consume
+   .contains
    .Date
    .dir
    .ENode
@@ -97,6 +98,7 @@ global_variables = {
    .setTimeout
    .spawn
    .Symbol
+   .take
    .this
    .TypeError
    .typeof

--- a/src/macros/consts.eg
+++ b/src/macros/consts.eg
@@ -10,60 +10,97 @@ inject:
 
 
 global_variables = {
-
-   "+", "-", "*", "/", "mod"
-   "&+", "|+", "^+"
-   "and", "or", "not"
-   ;; "==", "!="
-   "===", "!=="
-   "<", ">", "<=", ">="
-   "<<", ">>", ">>>"
-   "in", "instanceof", "--"
+   "!="
+   "!=="
+   "&"
+   "&+"
+   "&:"
+   "*"
+   "+"
    "++"
-
-   ;; .true, .false, .null, .undefined
-
-   .typeof
-   ;; .String, .Number, .Boolean
-   .Array, .Object, .Symbol
-   .RegExp, .Function, .Date
-   .parseInt, .parseFloat, .Math, .Infinity
-   .Error, .TypeError, .ReferenceError
-   .console, .process, .eval
-
-   .setTimeout, .clearTimeout
-   .setInterval, .clearInterval
-
-   .___js_fetch, .___node
-
-   .arguments, .this, .module, .exports
-
-   .send
-   .object, .keys, .items, .enumerate
-   .zip, .product, .neighbours, .range
-   .predicate
-   "==", "!="
-   .equal, .nequal
-   "&", "&:"
-   .clone, .dir
-   .getProjector, .getChecker
-   .ErrorFactory, .ENode
-   .repr, .getProperty
-
+   "-"
+   "--"
+   "/"
+   "<"
+   "<<"
+   "<="
+   "=="
+   "==="
+   ">"
+   ">="
+   ">>"
+   ">>>"
+   "^+"
+   "|+"
    .___build_array
-   .___hasprop
    .___extend
+   .___hasprop
+   .___js_fetch
    .___match_error
+   .___node
    .___serialize_ast
-
-   .JSON
-   .Set, .Map
-   .consume
-   .Promise, .promisify, .spawn
-
+   .__dirname
+   .__filename
+   .and
+   .arguments
+   .Array
    .Buffer
-
-   .global, .__dirname, .__filename
+   .clearInterval
+   .clearTimeout
+   .clone
+   .console
+   .consume
+   .Date
+   .dir
+   .ENode
+   .enumerate
+   .equal
+   .Error
+   .ErrorFactory
+   .eval
+   .exports
+   .Function
+   .getChecker
+   .getProjector
+   .getProperty
+   .global
+   .in
+   .Infinity
+   .instanceof
+   .items
+   .JSON
+   .keys
+   .Map
+   .Math
+   .mod
+   .module
+   .neighbours
+   .nequal
+   .not
+   .Object
+   .object
+   .or
+   .parseFloat
+   .parseInt
+   .predicate
+   .process
+   .product
+   .Promise
+   .promisify
+   .range
+   .ReferenceError
+   .RegExp
+   .repr
+   .send
+   .Set
+   .setInterval
+   .setTimeout
+   .spawn
+   .Symbol
+   .this
+   .TypeError
+   .typeof
+   .zip
 }
 
 global_variables each gvar ->

--- a/src/macros/consts.eg
+++ b/src/macros/consts.eg
@@ -44,22 +44,32 @@ global_variables = {
    .and
    .arguments
    .Array
+   .ArrayBuffer
    .Buffer
+   .clearImmediate
    .clearInterval
    .clearTimeout
    .clone
    .console
    .consume
    .contains
+   .DataView
    .Date
+   .decodeURI
+   .decodeURIComponent
    .dir
+   .encodeURI
+   .encodeURIComponent
    .ENode
    .enumerate
    .equal
    .Error
    .ErrorFactory
    .eval
+   .EvalError
    .exports
+   .Float32Array
+   .Float64Array
    .Function
    .getChecker
    .getProjector
@@ -68,6 +78,12 @@ global_variables = {
    .in
    .Infinity
    .instanceof
+   .Int16Array
+   .Int32Array
+   .Int8Array
+   .Intl
+   .isFinite
+   .isNaN
    .items
    .JSON
    .keys
@@ -75,6 +91,7 @@ global_variables = {
    .Math
    .mod
    .module
+   .NaN
    .neighbours
    .nequal
    .not
@@ -88,20 +105,32 @@ global_variables = {
    .product
    .Promise
    .promisify
+   .Proxy
    .range
+   .RangeError
    .ReferenceError
+   .Reflect
    .RegExp
    .repr
    .send
    .Set
+   .setImmediate
    .setInterval
    .setTimeout
    .spawn
    .Symbol
+   .SyntaxError
    .take
    .this
    .TypeError
    .typeof
+   .Uint16Array
+   .Uint32Array
+   .Uint8Array
+   .Uint8ClampedArray
+   .URIError
+   .WeakMap
+   .WeakSet
    .zip
 }
 

--- a/test/test-globals.eg
+++ b/test/test-globals.eg
@@ -1,0 +1,74 @@
+require-macros:
+   "earl-mocha" ->
+      describe, it
+
+
+JS_GLOBALS = {
+   .__dirname
+   .__filename
+   .Array
+   .ArrayBuffer
+   .Boolean
+   .Buffer
+   .clearImmediate
+   .clearInterval
+   .clearTimeout
+   .console
+   .DataView
+   .Date
+   .decodeURI
+   .decodeURIComponent
+   .encodeURI
+   .encodeURIComponent
+   .Error
+   .eval
+   .EvalError
+   .Float32Array
+   .Float64Array
+   .Function
+   .global
+   .Infinity
+   .Int16Array
+   .Int32Array
+   .Int8Array
+   .Intl
+   .isFinite
+   .isNaN
+   .JSON
+   .Map
+   .Math
+   .module
+   .NaN
+   .Object
+   .parseFloat
+   .parseInt
+   .process
+   .Promise
+   .Proxy
+   .RangeError
+   .ReferenceError
+   .Reflect
+   .RegExp
+   .Set
+   .setImmediate
+   .setInterval
+   .setTimeout
+   .String
+   .Symbol
+   .SyntaxError
+   .this
+   .TypeError
+   .Uint16Array
+   .Uint32Array
+   .Uint8Array
+   .Uint8ClampedArray
+   .URIError
+   .WeakMap
+   .WeakSet
+}
+
+
+describe "JavaScript and Node.js globals":
+   JS_GLOBALS each name ->
+      it 'should provide {name}':
+         eval(name)


### PR DESCRIPTION
The available globals in Earl Grey (without explicitly using `globals`) were missing several globals from JavaScript and Node.js, as well as two from Earl Grey's own runtime. This PR reformats the globals list, adds the missing globals, and adds a test suite to ensure that the JavaScript globals are available.