### PR TITLE
Fix kebab-case names in macro dependencies

### DIFF
--- a/src/macros/macrodef.eg
+++ b/src/macros/macrodef.eg
@@ -6,6 +6,7 @@ require:
       Env, topscope
    "./helpers" ->
       ctx_mac, expr_mac2, multimacro, inject-tools
+   "../util" -> camelCase
 
 inject: mac
 
@@ -63,7 +64,7 @@ mac{"macro"}! macro_mac = mak{{}} where
                       *provides
                       `tmp.__path = __filename`
                       `tmp`} where
-                  provides = tosave each sym and #symbol{name} ->
+                  provides = tosave each sym and #symbol{camelCase! name} ->
                      `provide{^sym as ^exp}, deps[^=name] = ^=expn` where
                         expn = "__mdep_" + name
                         exp = #symbol{expn}

--- a/test/macros.eg
+++ b/test/macros.eg
@@ -1,0 +1,29 @@
+provide:
+   add-two-macro
+   try-expand
+
+
+ast-as-array(ast) =
+   let contents = ast.map with match ->
+      Array? arr -> ast-as-array{arr}
+      x -> #value{x}
+   #data{*contents}
+
+
+macro try-expand(expr) =
+   try:
+      let expanded-ast = @expand(@context, expr)
+   catch err:
+      let msg = '{err.name}: {err.message}'
+      return `{false, ^=msg}`
+   `{true, ^ast-as-array(expanded-ast)}`
+
+
+add-two(x) = x + 1
+
+
+macro{add-two} add-two-macro(#data{#value{Number? v}}) =
+   let {=> add-two} = @deps
+   ```
+   [^add-two](^=v)
+   ```

--- a/test/test-macros.eg
+++ b/test/test-macros.eg
@@ -1,0 +1,12 @@
+require-macros:
+   "earl-mocha" ->
+      assert, describe, it
+   "./macros" ->
+      add-two-macro
+      try-expand
+
+
+describe "macros":
+   it "should permit kebab-case names in dependencies":
+      let {success, result} = try-expand(add-two-macro(4))
+      assert success


### PR DESCRIPTION
Using a kebab-case name in a macro's dependencies would cause the dependency to be registered as that kebab-case name, instead of camelCase. This would cause subsequent lookups for the dependency under `@deps` to fail, since `@deps.foo-bar` translates to camelCase.